### PR TITLE
Support Ubuntu 18.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Setup
 
 The easiest way to get going is to use https://github.com/Lullabot/trusty32-lamp
 which includes these commands. Otherwise, these scripts expect a
-thinly-provisioned LVM volume named "master" in a "mysql" volume group.
+thinly-provisioned LVM volume named "master" in a "vagrant-vg" volume group.
 
 LMM supports the following hooks in `/etc/lmm`. Each hook must be an executable
 file.

--- a/commands/branch
+++ b/commands/branch
@@ -16,6 +16,6 @@ then
   exit
 fi
 
-snapshot_available "/dev/$VG/$1"
+snapshot_available "/dev/$VG/mysql-$1"
 check_user
 branch $1

--- a/commands/checkout
+++ b/commands/checkout
@@ -9,7 +9,7 @@ then
   exit 1
 fi
 
-snapshot_exists "/dev/$VG/$1"
+snapshot_exists "/dev/$VG/mysql-$1"
 check_user
 
 snapshot_active $1

--- a/commands/delete
+++ b/commands/delete
@@ -15,7 +15,7 @@ then
   exit 1
 fi
 
-snapshot_exists "/dev/$VG/$1"
+snapshot_exists "/dev/$VG/mysql-$1"
 
 snapshot_active $1
 if [ $? -eq 0 ]

--- a/commands/merge
+++ b/commands/merge
@@ -9,7 +9,7 @@ then
   exit 1
 fi
 
-snapshot_exists "/dev/$VG/$1"
+snapshot_exists "/dev/$VG/mysql-$1"
 check_user
 
 merge "$VG_PATH/$1"

--- a/commands/status
+++ b/commands/status
@@ -10,6 +10,6 @@ echo "Active snapshot:" $(echo $(active) | sed "s/\/mysql\///")
 echo ""
 
 echo "Database snapshots:"
-lvs -o lv_name --noheadings | grep -v thinpool
+lvs -o lv_name --noheadings | grep -v thinpool | grep mysql- | sed 's/mysql-//'
 
-free
+free $VG

--- a/config.sh
+++ b/config.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # The name of the volume group for your databases.
-VG="mysql"
+VG="vagrant-vg"
 
 # The filesystem directory where databases will be mounted.
 VG_PATH="/$VG"

--- a/functions.sh
+++ b/functions.sh
@@ -23,7 +23,7 @@ check_user() {
 branch() {
   DEVICE=`device "$(active)"`
   systemctl stop mysql
-  lvcreate -s -K -n mysql-$1 "$DEVICE"
+  lvcreate --setactivationskip n -s -K -n mysql-$1 "$DEVICE"
   mkdir -p "$VG_PATH/$1"
   fstab_add $1
   mount -a

--- a/functions.sh
+++ b/functions.sh
@@ -22,12 +22,12 @@ check_user() {
 # Branch a new database from the master database.
 branch() {
   DEVICE=`device "$(active)"`
-  service mysql stop
-  lvcreate -s -n $1 "$DEVICE"
+  systemctl stop mysql
+  lvcreate -s -K -n mysql-$1 "$DEVICE"
   mkdir -p "$VG_PATH/$1"
   fstab_add $1
   mount -a
-  service mysql start
+  systemctl start mysql
 }
 
 # Destroy a database snapshot.
@@ -35,12 +35,12 @@ delete() {
   umount "$VG_PATH/$1"
   rmdir "$VG_PATH/$1"
   fstab_rm $1
-  lvremove -f "$VG/$1"
+  lvremove -f "$VG/mysql-$1"
 }
 
 # Display the amount of free space in the thin pool.
 free() {
-  PCT=`lvs mysql/thinpool -odata_percent --noheadings --rows | cut -c 3-`
+  PCT=`lvs $1/thinpool -odata_percent --noheadings --rows | cut -c 3-`
   echo ""
   echo "$PCT% used by MySQL databases."
 
@@ -55,7 +55,7 @@ free() {
 }
 
 fstab_definition() {
-  echo -e "/dev/$VG/$1\t/$VG/$1\text4\tdefaults\t0\t0" "# MySQL database added by LMM"
+  echo -e "/dev/$VG/mysql-$1\t/$VG/$1\text4\tdefaults\t0\t0" "# MySQL database added by LMM"
 }
 
 fstab_add() {
@@ -79,9 +79,9 @@ snapshot_exists() {
 # Merge a snapshot into the currently active snapshot.
 merge() {
   echo "Merging $1 into $(active)"
-  service mysql stop
+  systemctl stop mysql
   rsync -a --progress --delete-after "$1/" $(active)
-  service mysql start
+  systemctl start mysql
   fstrim $(active)
 }
 
@@ -107,7 +107,7 @@ snapshot_active() {
 # Change the currently active database.
 checkout() {
   echo `active` "is the currently active database."
-  service mysql stop
+  systemctl stop mysql
   echo "Setting $VG_PATH/$1 as the active database."
   rm /var/lib/mysql
   ln -s $VG_PATH/$1 /var/lib/mysql
@@ -115,5 +115,5 @@ checkout() {
   then
     /etc/lmm/post-checkout
   fi
-  service mysql start
+  systemctl start mysql
 }


### PR DESCRIPTION
This PR:

* Supports Ubuntu 18.04 by switching to `systemctl`
* Drops the requirement for a separate volume group
* Fixes thin volumes not being activated by default (upstream change in lvm)